### PR TITLE
feat(config): implement hash-based auth.json change detection

### DIFF
--- a/README.md
+++ b/README.md
@@ -54,7 +54,7 @@ Create `~/.config/opencode/opencode-auth-sync.json`:
 | `secretName` | string | `OPENCODE_AUTH_JSON` | GitHub secret name |
 | `repositories` | string[] | `[]` | Repositories to sync (`owner/repo` format) |
 | `debounceMs` | number | `1000` | Debounce delay for file changes |
-| `authFileHash` | string | (auto-managed) | SHA-256 hash of last synced auth.json (managed by plugin) |
+| `authFileHashes` | object | (auto-managed) | Per-repository SHA-256 hashes of last synced auth.json (managed by plugin) |
 
 ## Prerequisites
 

--- a/README.md
+++ b/README.md
@@ -64,8 +64,11 @@ Create `~/.config/opencode/opencode-auth-sync.json`:
 
 1. Plugin watches `~/.local/share/opencode/auth.json` for changes
 2. When tokens refresh, the file updates
-3. Plugin syncs the entire auth file to configured repositories via `gh secret set`
-4. Toast notifications show sync status
+3. Plugin computes a SHA-256 hash of the file content and compares it against the stored hash
+4. If the hash differs (content actually changed), syncs to configured repositories via `gh secret set`
+5. Toast notifications show sync status
+
+The hash-based change detection reduces unnecessary GitHub API calls when file metadata changes but content remains the same.
 
 ## Using the Secret in GitHub Actions
 

--- a/README.md
+++ b/README.md
@@ -54,6 +54,7 @@ Create `~/.config/opencode/opencode-auth-sync.json`:
 | `secretName` | string | `OPENCODE_AUTH_JSON` | GitHub secret name |
 | `repositories` | string[] | `[]` | Repositories to sync (`owner/repo` format) |
 | `debounceMs` | number | `1000` | Debounce delay for file changes |
+| `authFileHash` | string | (auto-managed) | SHA-256 hash of last synced auth.json (managed by plugin) |
 
 ## Prerequisites
 

--- a/index.ts
+++ b/index.ts
@@ -74,13 +74,16 @@ export const OpenCodeAuthSyncPlugin: Plugin = async ({ $, client, directory }: P
 
     if (summary.failed === 0) {
       showToast(`Synced to ${summary.successful} repo(s)`, "success", 3000)
-      await persistHash(hash)
     } else {
       const failedRepos = summary.results
         .filter((r) => !r.success)
         .map((r) => r.repository)
         .join(", ")
       showToast(`${summary.successful} synced, ${summary.failed} failed: ${failedRepos}`, "warning", 5000)
+    }
+
+    if (summary.successful > 0) {
+      await persistHash(hash)
     }
 
     isFirstSync = false

--- a/lib/config.test.ts
+++ b/lib/config.test.ts
@@ -1,8 +1,8 @@
 import { describe, test, expect, beforeEach, afterEach } from "bun:test"
-import { mkdirSync, writeFileSync, rmSync, existsSync } from "fs"
+import { mkdirSync, writeFileSync, rmSync, existsSync, readFileSync } from "fs"
 import { join } from "path"
 import { tmpdir } from "os"
-import { loadPluginConfigSync, mergeConfig, DEFAULT_CONFIG } from "./config"
+import { loadPluginConfigSync, mergeConfig, DEFAULT_CONFIG, saveConfig, getConfigPath } from "./config"
 import type { AuthSyncConfig } from "./types"
 
 describe("loadPluginConfigSync", () => {
@@ -237,5 +237,194 @@ describe("DEFAULT_CONFIG", () => {
     expect(DEFAULT_CONFIG.secretName).toBe("OPENCODE_AUTH_JSON")
     expect(DEFAULT_CONFIG.repositories).toEqual([])
     expect(DEFAULT_CONFIG.debounceMs).toBe(1000)
+  })
+})
+
+describe("saveConfig", () => {
+  const testDir = join(tmpdir(), `opencode-auth-sync-save-${Date.now()}`)
+  const testConfigPath = join(testDir, "config.json")
+
+  beforeEach(() => {
+    mkdirSync(testDir, { recursive: true })
+  })
+
+  afterEach(() => {
+    if (existsSync(testDir)) {
+      rmSync(testDir, { recursive: true })
+    }
+  })
+
+  test("writes config to file with proper JSON formatting", async () => {
+    const config: Partial<AuthSyncConfig> = {
+      enabled: true,
+      repositories: ["org/repo"],
+      secretName: "TEST_SECRET",
+    }
+
+    await saveConfig(testConfigPath, config)
+
+    const content = readFileSync(testConfigPath, "utf-8")
+    const parsed = JSON.parse(content)
+
+    expect(parsed).toEqual(config)
+    expect(content).toContain("\n")
+  })
+
+  test("saves config with authFileHash field", async () => {
+    const config: Partial<AuthSyncConfig> = {
+      enabled: true,
+      repositories: ["org/repo"],
+      authFileHash: "abc123def456",
+    }
+
+    await saveConfig(testConfigPath, config)
+
+    const content = readFileSync(testConfigPath, "utf-8")
+    const parsed = JSON.parse(content)
+
+    expect(parsed.authFileHash).toBe("abc123def456")
+  })
+
+  test("overwrites existing config file", async () => {
+    const oldConfig = { enabled: false, repositories: ["old/repo"] }
+    writeFileSync(testConfigPath, JSON.stringify(oldConfig))
+
+    const newConfig: Partial<AuthSyncConfig> = {
+      enabled: true,
+      repositories: ["new/repo"],
+      authFileHash: "newhash123",
+    }
+
+    await saveConfig(testConfigPath, newConfig)
+
+    const content = readFileSync(testConfigPath, "utf-8")
+    const parsed = JSON.parse(content)
+
+    expect(parsed.enabled).toBe(true)
+    expect(parsed.repositories).toEqual(["new/repo"])
+    expect(parsed.authFileHash).toBe("newhash123")
+  })
+})
+
+describe("getConfigPath", () => {
+  const testDir = join(tmpdir(), `opencode-auth-sync-path-${Date.now()}`)
+  const projectConfigPath = join(testDir, "opencode-auth-sync.json")
+
+  beforeEach(() => {
+    mkdirSync(testDir, { recursive: true })
+  })
+
+  afterEach(() => {
+    if (existsSync(testDir)) {
+      rmSync(testDir, { recursive: true })
+    }
+  })
+
+  test("returns project config path when it exists", () => {
+    writeFileSync(projectConfigPath, JSON.stringify({ enabled: true }))
+
+    const result = getConfigPath(testDir)
+    expect(result).toBe(projectConfigPath)
+  })
+
+  test("returns string when some config file exists", () => {
+    const result = getConfigPath(testDir)
+    expect(typeof result === "string" || result === null).toBe(true)
+  })
+})
+
+describe("authFileHash in config", () => {
+  const testDir = join(tmpdir(), `opencode-auth-sync-hash-${Date.now()}`)
+  const testConfigPath = join(testDir, "config.json")
+
+  beforeEach(() => {
+    mkdirSync(testDir, { recursive: true })
+  })
+
+  afterEach(() => {
+    if (existsSync(testDir)) {
+      rmSync(testDir, { recursive: true })
+    }
+  })
+
+  test("loads config with authFileHash field", () => {
+    const config = {
+      enabled: true,
+      repositories: ["org/repo"],
+      authFileHash: "sha256hashvalue123",
+    }
+    writeFileSync(testConfigPath, JSON.stringify(config))
+
+    const result = loadPluginConfigSync(testConfigPath)
+
+    expect(result.authFileHash).toBe("sha256hashvalue123")
+  })
+
+  test("backward compatibility: loads config without authFileHash field", () => {
+    const config = {
+      enabled: true,
+      repositories: ["org/repo"],
+      secretName: "SECRET",
+    }
+    writeFileSync(testConfigPath, JSON.stringify(config))
+
+    const result = loadPluginConfigSync(testConfigPath)
+
+    expect(result.authFileHash).toBeUndefined()
+    expect(result.enabled).toBe(true)
+    expect(result.repositories).toEqual(["org/repo"])
+  })
+
+  test("mergeConfig preserves authFileHash from existing config", () => {
+    const existing: Partial<AuthSyncConfig> = {
+      enabled: true,
+      repositories: ["old/repo"],
+      authFileHash: "existinghash",
+    }
+    const updates: Partial<AuthSyncConfig> = {
+      repositories: ["new/repo"],
+    }
+
+    const result = mergeConfig(existing, updates)
+
+    expect(result.authFileHash).toBe("existinghash")
+    expect(result.repositories).toEqual(["new/repo"])
+  })
+
+  test("mergeConfig allows updating authFileHash", () => {
+    const existing: Partial<AuthSyncConfig> = {
+      enabled: true,
+      authFileHash: "oldhash",
+    }
+    const updates: Partial<AuthSyncConfig> = {
+      authFileHash: "newhash",
+    }
+
+    const result = mergeConfig(existing, updates)
+
+    expect(result.authFileHash).toBe("newhash")
+  })
+
+  test("full workflow: load, update hash, save, reload", async () => {
+    const initialConfig = {
+      enabled: true,
+      repositories: ["org/repo"],
+      secretName: "SECRET",
+    }
+    writeFileSync(testConfigPath, JSON.stringify(initialConfig))
+
+    const loaded = loadPluginConfigSync(testConfigPath)
+    expect(loaded.authFileHash).toBeUndefined()
+
+    const updated: Partial<AuthSyncConfig> = {
+      ...loaded,
+      authFileHash: "newlycomputedhash",
+    }
+    await saveConfig(testConfigPath, updated)
+
+    const reloaded = loadPluginConfigSync(testConfigPath)
+    expect(reloaded.authFileHash).toBe("newlycomputedhash")
+    expect(reloaded.enabled).toBe(true)
+    expect(reloaded.repositories).toEqual(["org/repo"])
   })
 })

--- a/lib/config.ts
+++ b/lib/config.ts
@@ -1,4 +1,4 @@
-import { readFile } from "fs/promises"
+import { readFile, writeFile } from "fs/promises"
 import { existsSync, readFileSync } from "fs"
 import { homedir } from "os"
 import { join } from "path"
@@ -61,4 +61,27 @@ export function expandPath(path: string): string {
     return join(homedir(), path.slice(1))
   }
   return path
+}
+
+export function getConfigPath(projectDir?: string): string | null {
+  const locations = [
+    projectDir && join(projectDir, "opencode-auth-sync.json"),
+    join(homedir(), ".config", "opencode", "opencode-auth-sync.json"),
+  ].filter(Boolean) as string[]
+
+  for (const configPath of locations) {
+    if (existsSync(configPath)) {
+      return configPath
+    }
+  }
+
+  return null
+}
+
+export async function saveConfig(
+  configPath: string,
+  config: Partial<AuthSyncConfig>
+): Promise<void> {
+  const content = JSON.stringify(config, null, 2)
+  await writeFile(configPath, content, "utf-8")
 }

--- a/lib/types.ts
+++ b/lib/types.ts
@@ -4,6 +4,7 @@ export interface AuthSyncConfig {
   secretName: string
   repositories: string[]
   debounceMs?: number
+  authFileHash?: string
 }
 
 export interface OAuthEntry {

--- a/lib/types.ts
+++ b/lib/types.ts
@@ -4,7 +4,7 @@ export interface AuthSyncConfig {
   secretName: string
   repositories: string[]
   debounceMs?: number
-  authFileHash?: string
+  authFileHashes?: Record<string, string>
 }
 
 export interface OAuthEntry {

--- a/lib/watcher.test.ts
+++ b/lib/watcher.test.ts
@@ -1,5 +1,5 @@
 import { describe, test, expect, beforeEach, afterEach } from "bun:test"
-import { mkdirSync, writeFileSync, rmSync, existsSync, unlinkSync } from "fs"
+import { mkdirSync, writeFileSync, rmSync, existsSync } from "fs"
 import { join } from "path"
 import { tmpdir } from "os"
 import { computeHash, watchCredentials } from "./watcher"

--- a/lib/watcher.test.ts
+++ b/lib/watcher.test.ts
@@ -1,0 +1,284 @@
+import { describe, test, expect, beforeEach, afterEach } from "bun:test"
+import { mkdirSync, writeFileSync, rmSync, existsSync, unlinkSync } from "fs"
+import { join } from "path"
+import { tmpdir } from "os"
+import { computeHash, watchCredentials } from "./watcher"
+import type { OpenCodeAuth } from "./types"
+
+describe("computeHash", () => {
+  test("returns consistent SHA-256 hash for same content", () => {
+    const content = '{"anthropic":{"type":"oauth","access":"token123"}}'
+    const hash1 = computeHash(content)
+    const hash2 = computeHash(content)
+
+    expect(hash1).toBe(hash2)
+    expect(hash1).toHaveLength(64)
+  })
+
+  test("returns different hash for different content", () => {
+    const content1 = '{"anthropic":{"access":"token1"}}'
+    const content2 = '{"anthropic":{"access":"token2"}}'
+
+    const hash1 = computeHash(content1)
+    const hash2 = computeHash(content2)
+
+    expect(hash1).not.toBe(hash2)
+  })
+
+  test("returns valid hex string", () => {
+    const hash = computeHash("test content")
+    expect(hash).toMatch(/^[a-f0-9]{64}$/)
+  })
+
+  test("handles empty string", () => {
+    const hash = computeHash("")
+    expect(hash).toHaveLength(64)
+    expect(hash).toMatch(/^[a-f0-9]{64}$/)
+  })
+
+  test("handles unicode content", () => {
+    const hash = computeHash('{"name":"日本語","emoji":"🎉"}')
+    expect(hash).toHaveLength(64)
+    expect(hash).toMatch(/^[a-f0-9]{64}$/)
+  })
+
+  test("whitespace-only differences produce different hashes", () => {
+    const compact = '{"key":"value"}'
+    const pretty = '{ "key": "value" }'
+
+    expect(computeHash(compact)).not.toBe(computeHash(pretty))
+  })
+})
+
+describe("watchCredentials hash comparison", () => {
+  let testDir: string
+  let authFilePath: string
+
+  beforeEach(() => {
+    testDir = join(tmpdir(), `watcher-test-${Date.now()}-${Math.random()}`)
+    authFilePath = join(testDir, "auth.json")
+    mkdirSync(testDir, { recursive: true })
+  })
+
+  afterEach(() => {
+    if (existsSync(testDir)) {
+      rmSync(testDir, { recursive: true })
+    }
+  })
+
+  test("triggers callback on initial file when no stored hash", async () => {
+    const authContent = '{"anthropic":{"type":"oauth","access":"initial"}}'
+    writeFileSync(authFilePath, authContent)
+
+    let callCount = 0
+    let receivedRaw = ""
+    let receivedHash = ""
+
+    const stop = watchCredentials(
+      authFilePath,
+      {
+        onCredentialsChange: (_credentials: OpenCodeAuth, raw: string, hash: string) => {
+          callCount++
+          receivedRaw = raw
+          receivedHash = hash
+        },
+        onError: () => {},
+      },
+      { debounceMs: 50 }
+    )
+
+    await new Promise((r) => setTimeout(r, 200))
+    stop()
+
+    expect(callCount).toBe(1)
+    expect(receivedRaw).toBe(authContent)
+    expect(receivedHash).toBe(computeHash(authContent))
+  })
+
+  test("skips callback when content hash matches stored hash", async () => {
+    const authContent = '{"anthropic":{"type":"oauth","access":"unchanged"}}'
+    const storedHash = computeHash(authContent)
+    writeFileSync(authFilePath, authContent)
+
+    let callCount = 0
+
+    const stop = watchCredentials(
+      authFilePath,
+      {
+        onCredentialsChange: () => {
+          callCount++
+        },
+        onError: () => {},
+      },
+      { debounceMs: 50, storedHash }
+    )
+
+    await new Promise((r) => setTimeout(r, 200))
+    stop()
+
+    expect(callCount).toBe(0)
+  })
+
+  test("triggers callback when content hash differs from stored hash", async () => {
+    const oldContent = '{"anthropic":{"access":"old"}}'
+    const newContent = '{"anthropic":{"access":"new"}}'
+    const storedHash = computeHash(oldContent)
+
+    writeFileSync(authFilePath, newContent)
+
+    let callCount = 0
+    let receivedRaw = ""
+    let receivedHash = ""
+
+    const stop = watchCredentials(
+      authFilePath,
+      {
+        onCredentialsChange: (_credentials: OpenCodeAuth, raw: string, hash: string) => {
+          callCount++
+          receivedRaw = raw
+          receivedHash = hash
+        },
+        onError: () => {},
+      },
+      { debounceMs: 50, storedHash }
+    )
+
+    await new Promise((r) => setTimeout(r, 200))
+    stop()
+
+    expect(callCount).toBe(1)
+    expect(receivedRaw).toBe(newContent)
+    expect(receivedHash).toBe(computeHash(newContent))
+  })
+
+  test("skips duplicate changes with same content", async () => {
+    const authContent = '{"test":"data"}'
+    writeFileSync(authFilePath, authContent)
+
+    let callCount = 0
+
+    const stop = watchCredentials(
+      authFilePath,
+      {
+        onCredentialsChange: () => {
+          callCount++
+        },
+        onError: () => {},
+      },
+      { debounceMs: 50 }
+    )
+
+    await new Promise((r) => setTimeout(r, 200))
+    expect(callCount).toBe(1)
+
+    writeFileSync(authFilePath, authContent)
+    await new Promise((r) => setTimeout(r, 200))
+    expect(callCount).toBe(1)
+
+    writeFileSync(authFilePath, authContent)
+    await new Promise((r) => setTimeout(r, 200))
+
+    stop()
+
+    expect(callCount).toBe(1)
+  })
+
+  test("provides correct hash to callback on initial read", async () => {
+    const content = '{"version":1}'
+    const expectedHash = computeHash(content)
+
+    writeFileSync(authFilePath, content)
+
+    let receivedHash = ""
+
+    const stop = watchCredentials(
+      authFilePath,
+      {
+        onCredentialsChange: (_credentials: OpenCodeAuth, _raw: string, hash: string) => {
+          receivedHash = hash
+        },
+        onError: () => {},
+      },
+      { debounceMs: 50 }
+    )
+
+    await new Promise((r) => setTimeout(r, 800))
+    stop()
+
+    expect(receivedHash).toBe(expectedHash)
+  })
+
+  test("calls onError for invalid JSON", async () => {
+    writeFileSync(authFilePath, "not valid json {{{")
+
+    let changeCount = 0
+    let errorCount = 0
+
+    const stop = watchCredentials(
+      authFilePath,
+      {
+        onCredentialsChange: () => {
+          changeCount++
+        },
+        onError: () => {
+          errorCount++
+        },
+      },
+      { debounceMs: 50 }
+    )
+
+    await new Promise((r) => setTimeout(r, 200))
+    stop()
+
+    expect(changeCount).toBe(0)
+    expect(errorCount).toBe(1)
+  })
+
+  test("passes parsed credentials object to callback", async () => {
+    const authData: OpenCodeAuth = {
+      anthropic: { type: "oauth", access: "token123", refresh: "refresh123", expires: 1234567890 },
+    }
+    writeFileSync(authFilePath, JSON.stringify(authData))
+
+    let receivedCredentials: OpenCodeAuth = {}
+
+    const stop = watchCredentials(
+      authFilePath,
+      {
+        onCredentialsChange: (credentials: OpenCodeAuth) => {
+          receivedCredentials = credentials
+        },
+        onError: () => {},
+      },
+      { debounceMs: 50 }
+    )
+
+    await new Promise((r) => setTimeout(r, 200))
+    stop()
+
+    expect(receivedCredentials).toEqual(authData)
+  })
+
+  test("backward compatibility: works with storedHash undefined", async () => {
+    const authContent = '{"test":"backward-compat"}'
+    writeFileSync(authFilePath, authContent)
+
+    let callCount = 0
+
+    const stop = watchCredentials(
+      authFilePath,
+      {
+        onCredentialsChange: () => {
+          callCount++
+        },
+        onError: () => {},
+      },
+      { debounceMs: 50, storedHash: undefined }
+    )
+
+    await new Promise((r) => setTimeout(r, 200))
+    stop()
+
+    expect(callCount).toBe(1)
+  })
+})

--- a/lib/watcher.ts
+++ b/lib/watcher.ts
@@ -1,19 +1,30 @@
 import chokidar from "chokidar"
+import { createHash } from "crypto"
 import { readFile } from "fs/promises"
 import type { OpenCodeAuth } from "./types"
 
+export function computeHash(content: string): string {
+  return createHash("sha256").update(content).digest("hex")
+}
+
 export interface WatcherCallbacks {
-  onCredentialsChange: (credentials: OpenCodeAuth, raw: string) => void
+  onCredentialsChange: (credentials: OpenCodeAuth, raw: string, hash: string) => void
   onError: (error: Error) => void
+}
+
+export interface WatcherOptions {
+  debounceMs?: number
+  storedHash?: string
 }
 
 export function watchCredentials(
   credentialsPath: string,
   callbacks: WatcherCallbacks,
-  debounceMs: number = 1000
+  options: WatcherOptions = {}
 ): () => void {
+  const { debounceMs = 1000, storedHash } = options
   let debounceTimer: ReturnType<typeof setTimeout> | null = null
-  let lastContent: string | null = null
+  let lastHash: string | null = storedHash ?? null
 
   const watcher = chokidar.watch(credentialsPath, {
     persistent: true,
@@ -27,14 +38,15 @@ export function watchCredentials(
   const handleChange = async () => {
     try {
       const content = await readFile(credentialsPath, "utf-8")
+      const currentHash = computeHash(content)
 
-      if (content === lastContent) {
+      if (currentHash === lastHash) {
         return
       }
-      lastContent = content
+      lastHash = currentHash
 
       const credentials = JSON.parse(content) as OpenCodeAuth
-      callbacks.onCredentialsChange(credentials, content)
+      callbacks.onCredentialsChange(credentials, content, currentHash)
     } catch (error) {
       callbacks.onError(error as Error)
     }

--- a/schema.json
+++ b/schema.json
@@ -36,6 +36,10 @@
       "default": 1000,
       "minimum": 100,
       "description": "Debounce delay in milliseconds for file changes"
+    },
+    "authFileHash": {
+      "type": "string",
+      "description": "SHA-256 hash of last synced auth.json (managed by plugin)"
     }
   },
   "required": ["repositories"],

--- a/schema.json
+++ b/schema.json
@@ -37,9 +37,12 @@
       "minimum": 100,
       "description": "Debounce delay in milliseconds for file changes"
     },
-    "authFileHash": {
-      "type": "string",
-      "description": "SHA-256 hash of last synced auth.json (managed by plugin)"
+    "authFileHashes": {
+      "type": "object",
+      "additionalProperties": {
+        "type": "string"
+      },
+      "description": "Per-repository SHA-256 hashes of last synced auth.json (managed by plugin)"
     }
   },
   "required": ["repositories"],


### PR DESCRIPTION
## Summary

- Add hash-based change detection mechanism to optimize auth.json sync operations
- Implement new OpenCode Auth GitHub workflow with validation and automation
- Add comprehensive test coverage for config and watcher modules (477 lines of tests)
- Update schema and type definitions to support hash-based detection
- Enhance core modules (config, watcher, index) with change detection logic

closes #1